### PR TITLE
stop query handle when tmpl is destroyed

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'smeevil:reactive-block-grid',
   summary: 'Given a cursor and a template this will create a reactive responsive block grid based on isotope',
-  version: '1.0.2',
+  version: '1.0.3',
   git: 'https://github.com/smeevil/responsive-block-grid.git'
 });
 

--- a/reactive_block_grid.coffee
+++ b/reactive_block_grid.coffee
@@ -26,6 +26,11 @@ Template.reactiveBlockGrid.helpers
   cssClasses: ->
     @cssClass
 
+Template.reactiveBlockGrid.destroyed = ()->
+  if @queryHandle
+    @queryHandle.stop()
+    @queryHandle = null
+
 Template.reactiveBlockGrid.rendered = ()->
   options={
     itemSelector: 'li'
@@ -59,7 +64,7 @@ Template.reactiveBlockGrid.rendered = ()->
 
   if @data.cursor.limit? || @data.cursor.skip?
 
-    @data.cursor.observeChanges
+    @queryHandle = @data.cursor.observeChanges
       addedBefore: -> null
       movedBefore: -> null
 
@@ -69,7 +74,7 @@ Template.reactiveBlockGrid.rendered = ()->
         $el.isotope('remove', item).isotope('layout')
 
   else
-    @data.cursor.observe
+    @queryHandle = @data.cursor.observe
       removed: (doc) ->
         selector="[data-reactive-block-grid-item-id=#{doc._id}]"
         item=$el.find(selector)


### PR DESCRIPTION
Previously the query created with `observe` or `observeChanges` would run forever.
When an element is removed from the collection after the grid has been removed form the DOM, it would cause isotope to throw errors.

By stopping the query when the template is destroyed, these errors are avoided. This further improves performance as the query doesn't continue running for no reason.

I also bumped the version number, so you can go ahead with the release :)

Closes #6 

_I have not verified these fixes actually work, so you may want to double check. I am confident it will work because I used the same fixes in another project using an inlined version of this package. So the approach is guaranteed to be correct, I'm just not sure I made a typo or something._
